### PR TITLE
ECO-442:  show whole transaction hash

### DIFF
--- a/src/popup/components/SignMessagePage.tsx
+++ b/src/popup/components/SignMessagePage.tsx
@@ -32,7 +32,9 @@ class SignMessagePage extends React.Component<Props, {}> {
 
           <div className="mt-5 mb-3">
             <p>Deploy hash (base16):</p>
-            <p>{this.props.signMessageContainer.toSignMessage!.data}</p>
+            <p style={{ wordBreak: 'break-all' }}>
+              {this.props.signMessageContainer.toSignMessage!.data}
+            </p>
           </div>
           <div className="text-center mt-5">
             <ListInline>


### PR DESCRIPTION
Show whole transaction hash while signing transactions.

Preview: 
![image](https://user-images.githubusercontent.com/7604540/85408808-9902ad00-b597-11ea-950e-ffb2ae238899.png)
