### PR TITLE
ECO-482: Reject request when user has changed the active key when signing

### DIFF
--- a/src/content/inpage.ts
+++ b/src/content/inpage.ts
@@ -15,8 +15,8 @@ class CasperLabsPluginHelper {
     return true;
   }
 
-  async sign(message: String) {
-    return this.call<string>('sign', message);
+  async sign(message: string, publicKeyBase64?: string) {
+    return this.call<string>('sign', message, publicKeyBase64);
   }
 
   async getSelectedPublicKeyBase64() {


### PR DESCRIPTION
### Overview

The signer could change active key when approving, but deployHash is bind to the last active key, so we need to show users a message that he needs to resend the request.  And the related updates in Explorer is included in https://github.com/CasperLabs/CasperLabs/pull/2109.

#### back and forward compatibility
Both are supported. 

If users use old version plugin and Clarity from this branch, Signer just ignores the second argument(`publicKeyBase64`).  Because in JavaScript:

```
const f = (a)=> console.log(a);
f("h", "e") // print 'h' and doesn't throw error. 
```
If users use the plugin from this branch and Clarity without updates, the second argument(`publicKeyBase64`) is undefined, the plugin won't check and works as before. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-482

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
