### PR TITLE
[ECO-651] Update Buffer Syntax and CSS Fix

### DIFF
--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -270,7 +270,7 @@ class AuthController {
    * @param str
    */
   private hash(str: string) {
-    const b = new Buffer(str);
+    const b = Buffer.from(str);
     const h = nacl.hash(Uint8Array.from(b));
     return encodeBase64(h);
   }

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -141,7 +141,7 @@ class Home extends React.Component<Props, {}> {
 
   resetVaultOnClick() {
     confirm(
-      <div className="text-danger">Danger!!!</div>,
+      <div className="text-danger">Danger!</div>,
       'Resetting vault will delete all imported accounts.'
     ).then(() => this.props.authContainer.resetVault());
   }
@@ -198,6 +198,7 @@ class Home extends React.Component<Props, {}> {
                 <a
                   href="#"
                   className="text-danger"
+                  id="reset-link"
                   onClick={() => this.resetVaultOnClick()}
                 >
                   Reset Vault?

--- a/src/popup/styles/custom.scss
+++ b/src/popup/styles/custom.scss
@@ -27,5 +27,11 @@ button.link {
 
 .reset-vault {
   text-align: center;
-  font-size: smaller;
+  font-size: small;
+  padding-top: 0.6rem;
+}
+
+.text-danger {
+  text-decoration: none;
+  color: red;
 }


### PR DESCRIPTION
I replaced the deprecated syntax for the Buffer with the updated form.
I added styling to the Reset Vault link on the pop up - screenshot attached.  

![Screenshot from 2020-09-07 21-48-09](https://user-images.githubusercontent.com/69711689/92416296-b128a800-f154-11ea-8acb-08dfdb87d03b.png)

