### PR TITLE
[ECO-652] List Keys with Account Identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6397,6 +6397,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js": {
       "version": "3.6.5",
@@ -19923,6 +19931,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.19.2",
     "browser-passworder": "^2.0.3",
     "casperlabs-sdk": "^0.9.2",
+    "copy-to-clipboard": "^3.3.1",
     "file-saver": "^2.0.2",
     "fontsource-roboto": "^2.2.3",
     "formik": "^2.1.4",

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -59,8 +59,6 @@ export const AccountManagementPage = observer((props: Props) => {
   const [publicKey64, setPublicKey64] = React.useState('');
   const [publicKeyHex, setPublicKeyHex] = React.useState('');
   const [copyStatus, setCopyStatus] = React.useState(false);
-  const keyTextRef = React.useRef(null);
-  const addressTextRef = React.useRef(null);
 
   const handleClickOpen = (account: SignKeyPairWithAlias) => {
     setOpenDialog(true);

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -58,6 +58,8 @@ export const AccountManagementPage = observer((props: Props) => {
   const [name, setName] = React.useState('');
   const [publicKey64, setPublicKey64] = React.useState('');
   const [publicKeyHex, setPublicKeyHex] = React.useState('');
+  /* Note: 01 prefix denotes algorithm used in key generation */
+  const address = '01' + publicKeyHex;
   const [copyStatus, setCopyStatus] = React.useState(false);
 
   const handleClickOpen = (account: SignKeyPairWithAlias) => {
@@ -227,14 +229,13 @@ export const AccountManagementPage = observer((props: Props) => {
               <IconButton
                 edge={'start'}
                 onClick={() => {
-                  copy('01' + publicKeyHex);
+                  copy(address);
                   setCopyStatus(true);
                 }}
               >
                 <FilterNoneIcon />
               </IconButton>
-              {/* Note: 01 prefix denotes algorithm used in key generation */}
-              <ListItemText primary={'Address: 01' + publicKeyHex} />
+              <ListItemText primary={'Address: ' + address} />
             </ListItem>
             <ListItem>
               <IconButton

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -221,47 +221,32 @@ export const AccountManagementPage = observer((props: Props) => {
         <DialogContent>
           <List>
             <ListItem>
-              <ListItemText>Name: {name}</ListItemText>
+              <ListItemText primary={'Name: ' + name} />
             </ListItem>
             <ListItem>
-              <ListItemText
-                ref={addressTextRef}
-                defaultValue="Default Account Address"
+              <IconButton
+                edge={'start'}
+                onClick={() => {
+                  copy('01' + publicKeyHex);
+                  setCopyStatus(true);
+                }}
               >
-                <IconButton
-                  edge={'start'}
-                  onClick={() => {
-                    copy('01' + publicKeyHex, {
-                      message: 'Copy Address',
-                      onCopy() {
-                        setCopyStatus(true);
-                      }
-                    });
-                  }}
-                >
-                  <FilterNoneIcon />
-                </IconButton>
-                {/* Note: 01 prefix denotes algorithm used in key generation */}
-                Address: 01{publicKeyHex}
-              </ListItemText>
+                <FilterNoneIcon />
+              </IconButton>
+              {/* Note: 01 prefix denotes algorithm used in key generation */}
+              <ListItemText primary={'Address: 01' + publicKeyHex} />
             </ListItem>
             <ListItem>
-              <ListItemText ref={keyTextRef}>
-                <IconButton
-                  edge={'start'}
-                  onClick={() => {
-                    copy(publicKey64, {
-                      message: 'Copy Public Key',
-                      onCopy() {
-                        setCopyStatus(true);
-                      }
-                    });
-                  }}
-                >
-                  <FilterNoneIcon />
-                </IconButton>
-                Public Key: {publicKey64}
-              </ListItemText>
+              <IconButton
+                edge={'start'}
+                onClick={() => {
+                  copy(publicKey64);
+                  setCopyStatus(true);
+                }}
+              >
+                <FilterNoneIcon />
+              </IconButton>
+              <ListItemText primary={'Public Key: ' + publicKey64} />
             </ListItem>
           </List>
           <Snackbar

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from 'react';
+import React from 'react';
 import {
   List,
   ListItem,

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -10,7 +10,9 @@ import {
   DialogActions,
   Button,
   Input,
-  Snackbar
+  Snackbar,
+  ListSubheader,
+  Typography
 } from '@material-ui/core';
 import RootRef from '@material-ui/core/RootRef';
 import {
@@ -222,9 +224,9 @@ export const AccountManagementPage = observer((props: Props) => {
         <DialogTitle id="form-dialog-title">Account Details</DialogTitle>
         <DialogContent>
           <List>
-            <ListItem>
-              <ListItemText primary={'Name: ' + name} />
-            </ListItem>
+            <ListSubheader>
+              <Typography variant={'h6'}>{name}</Typography>
+            </ListSubheader>
             <ListItem>
               <IconButton
                 edge={'start'}
@@ -235,7 +237,10 @@ export const AccountManagementPage = observer((props: Props) => {
               >
                 <FilterNoneIcon />
               </IconButton>
-              <ListItemText primary={'Address: ' + address} />
+              <ListItemText
+                primary={'Address: ' + address}
+                style={{ overflowWrap: 'break-word' }}
+              />
             </ListItem>
             <ListItem>
               <IconButton
@@ -247,7 +252,10 @@ export const AccountManagementPage = observer((props: Props) => {
               >
                 <FilterNoneIcon />
               </IconButton>
-              <ListItemText primary={'Public Key: ' + publicKey64} />
+              <ListItemText
+                primary={'Public Key: ' + publicKey64}
+                style={{ overflowWrap: 'break-word' }}
+              />
             </ListItem>
           </List>
           <Snackbar

--- a/src/popup/container/AccountManager.ts
+++ b/src/popup/container/AccountManager.ts
@@ -92,6 +92,19 @@ class AccountManager {
     );
   }
 
+  async getSelectedAccountKey(acctName: string) {
+    await this.backgroundManager.switchToAccount(acctName);
+    let account = await this.backgroundManager.getSelectUserAccount();
+    let key = account.signKeyPair.publicKey;
+    return key;
+  }
+
+  async getPublicKeyHex(acctName: string) {
+    let pubKey64 = await this.getSelectedAccountKey(acctName);
+    let pubKeyHex = encodeBase16(decodeBase64(pubKey64));
+    return pubKeyHex;
+  }
+
   async lock() {
     return this.backgroundManager.lock();
   }


### PR DESCRIPTION
This adds the ability to view account details from the Key Management page.
Users can now see Name/Alias, Address (Public Key Hex) and Public Key which can be copied easily with the use of a button to improve UX.


![Screenshot from 2020-09-20 18-03-59](https://user-images.githubusercontent.com/69711689/93717140-b382fd00-fb6b-11ea-9f30-435beb21cc7d.png)
