### PR TITLE
ECO-708 & ECO-675*

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.casperlabs.io/*", "*://localhost/*"],
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",
       "all_frames": true


### PR DESCRIPTION
**[708](https://casperlabs.atlassian.net/browse/ECO-708?atlOrigin=eyJpIjoiYTI1MjNmYTk4ZGVkNDVjOGE2NWRmYWZhM2NlMzM0NDciLCJwIjoiaiJ9)**:  Changes manifest to allow Signer to work on any site instead of only allowing Clarity and localhost.

**[675](https://casperlabs.atlassian.net/browse/ECO-675?atlOrigin=eyJpIjoiMGRmY2NiMzIzNzVkNDVlOGFjZmVlMmMzNjI2MmY4NmEiLCJwIjoiaiJ9)**: I haven't removed the 'unsafe-eval' tag from the `manifest.json` as on reviewing the code allowed by it I think it will be fine. Provided we abide by the rules/guidance laid out [here](https://eslint.org/docs/rules/no-implied-eval#disallow-implied-eval-no-implied-eval) from ESlint and avoid explicit `eval()` too.
`setTimeout()` is used throughout Metamask's repo (in line with the aforementioned rules) so I think it is fair to leave it in as is.
Feel free to comment any queries about this and I'll get back to you.